### PR TITLE
Removed the trailing slash which will confuse `package-vc-install`

### DIFF
--- a/README.org
+++ b/README.org
@@ -100,7 +100,7 @@ Requirements:
 
 If you use Emacs 29, you can install the package via
 
-~M-x package-vc-install RET https://github.com/ichernyshovvv/org-timeblock/ RET~
+~M-x package-vc-install RET https://github.com/ichernyshovvv/org-timeblock RET~
 
 ** Guix
 


### PR DESCRIPTION
For whatever reason I was getting the error 
```
Debugger entered--Lisp error: (args-out-of-range #<buffer custom.el> 1182 1191)
```
When typing the given keys. After running `(package-vc-install "https://github.com/ichernyshovvv/org-timeblock/")` I realized it was due to the trailing `/`.