### PR TITLE
Add org-timeblock-todo-set

### DIFF
--- a/README.org
+++ b/README.org
@@ -25,7 +25,7 @@ org-timeblock-mode buffer:
 You can press ~[t]~ to toggle the display of org-timeblock-list-mode
 buffer.  Foreground colors for timeblocks are generated randomly, but
 you can assign specific background and foreground colors in
-customizable variable ~org-timeblock-tag-colors~: 
+customizable variable ~org-timeblock-tag-colors~:
 
 [[file:screenshots/org-timeblock-with-list-mode.png]]
 
@@ -69,6 +69,7 @@ There are two major modes provided by the package:
   - org-timeblock-switch-view ~[V]~
   - org-timeblock-write ~[w]~
   - org-timeblock-jump-to-day ~[j]~
+  - org-timeblock-todo-set ~[T]~
 
 - ~org-timeblock-list-mode~.  Displays a list of org tasks that are
   scheduled or orgmode events for selected day.  It's sort of like a
@@ -88,6 +89,7 @@ There are two major modes provided by the package:
   - org-timeblock-switch-scaling ~[v]~
   - org-timeblock-switch-view ~[V]~
   - org-timeblock-list-toggle-timeblock ~[t]~
+  - org-timeblock-todo-set ~[T]~
 
 * Installation
 :PROPERTIES:

--- a/org-timeblock.el
+++ b/org-timeblock.el
@@ -212,6 +212,7 @@ tasks and those tasks that have not been sorted yet.")
   "C-s" #'org-timeblock-save
   "s" #'org-timeblock-schedule
   "t" #'org-timeblock-toggle-timeblock-list
+  "T" #'org-timeblock-todo-set
   "v" #'org-timeblock-switch-scaling
   "V" #'org-timeblock-switch-view
   "w" #'org-timeblock-write)
@@ -236,6 +237,7 @@ tasks and those tasks that have not been sorted yet.")
   "q" #'org-timeblock-quit
   "s" #'org-timeblock-list-schedule
   "t" #'org-timeblock-list-toggle-timeblock
+  "T" #'org-timeblock-todo-set
   "v" #'org-timeblock-switch-scaling
   "V" #'org-timeblock-switch-view)
 
@@ -254,6 +256,25 @@ tasks and those tasks that have not been sorted yet.")
 	  (org-timeblock-redraw-buffers))))
     (define-key org-timeblock-list-mode-map (kbd (cdr elem)) command-name)
     (define-key org-timeblock-mode-map (kbd (cdr elem)) command-name)))
+
+(defun org-timeblock-todo-set (&optional arg)
+  "Change the TODO state of an item in org-timeblock.
+
+Check `org-todo' for more information, including on the values of
+ARG."
+  (interactive "P")
+  (when-let ((marker
+              (pcase major-mode
+			    (`org-timeblock-list-mode
+			     (get-text-property (line-beginning-position) 'marker))
+			    (`org-timeblock-mode
+			     (org-timeblock-selected-block-marker)))))
+	(with-current-buffer (marker-buffer marker)
+      (save-excursion
+        (goto-char marker)
+        (org-timeblock-show-context)
+        (org-todo arg)))
+	(org-timeblock-redraw-buffers)))
 
 ;;;; Modes
 


### PR DESCRIPTION
This adds a command called `org-timeblock-todo-set` which calls `org-todo` on the current item.

`org-todo` has some logic that is not covered by your `(dolist (elem org-timeblock-fast-todo-commands) ...)` thing, for instance `C-u M-x org-todo` invokes a logging note.

Moreover, `org-todo` with `nil` either cycles the TODO state or prompts the user for the desired TODO state, e.g.:

![image](https://github.com/ichernyshovvv/org-timeblock/assets/21692287/75c43c4f-7c06-4700-b594-67a0d83180b5)

That's how `org-agenda-todo` works (although it does `(let ((current-prefix-arg arg)) (call-interactively 'org-todo))`, which seems unnecessary).

I'd call that `org-timeblock-todo` and ditch `(dolist (elem org-timeblock-fast-todo-commands) ...)` altogether, but a breaking change is up to you.