### PR TITLE
Fix: Clear cache when customizing org-timeblock-files

### DIFF
--- a/org-timeblock.el
+++ b/org-timeblock.el
@@ -178,7 +178,12 @@ Otherwise, it may be set to a list of filenames."
   :group 'org-timeblock
   :type '(choice
 	  (repeat :tag "List of files" file)
-	  (const :tag "Files from (org-agenda-files)" agenda)))
+	  (const :tag "Files from (org-agenda-files)" agenda))
+  :set (lambda (option value)
+         (set-default option value)
+         (setq org-timeblock-cache nil)
+         (setq org-timeblock-buffers nil)
+         (setq org-timeblock-markers nil)))
 
 (defcustom org-timeblock-show-outline-path nil
   "Non-nil means show outline path in echo area for the selected item."


### PR DESCRIPTION
Previously, changing the value of org-timeblock-files added new entries, but did not remove old stale entries which were no longer contained in the new value.  After this commit, if you (1) set org-timeblock-files to 'agenda, (2) run M-x org-timeblock, (3) set org-timeblock-files to "`~/foobar.org"` (*not with setq*, but with setopt, customize-set-variable, Customize interface, etc.), and finally (4) run M-x org-timeblock again, then you will see that only the entries in `"~/foobar.org"` appear and not the entries previously displayed from the files listed in org-agenda.